### PR TITLE
M0: add AST/diagnostic primitives completion for issue #7

### DIFF
--- a/compiler/src/diagnostics.ts
+++ b/compiler/src/diagnostics.ts
@@ -1,4 +1,4 @@
-import type { SourceRange } from "./ast.ts";
+import type { SourcePosition, SourceRange } from "./ast.ts";
 
 export type DiagnosticCode =
   | "LEX_UNEXPECTED_CHARACTER"
@@ -9,8 +9,73 @@ export type DiagnosticCode =
   | "PARSE_UNEXPECTED_TOKEN"
   | "PARSE_MISSING_REQUIRED_DECLARATION";
 
+export type DiagnosticSeverity = "error";
+
+export interface DiagnosticSpan {
+  file: string;
+  start: SourcePosition;
+  end: SourcePosition;
+}
+
 export interface Diagnostic {
   code: DiagnosticCode;
   message: string;
-  range: SourceRange;
+  severity: DiagnosticSeverity;
+  span: DiagnosticSpan;
+}
+
+export const DEFAULT_DIAGNOSTIC_FILE = "<input>";
+
+const DIAGNOSTIC_SEVERITY_BY_CODE: Record<DiagnosticCode, DiagnosticSeverity> = {
+  LEX_UNEXPECTED_CHARACTER: "error",
+  LEX_UNTERMINATED_STRING: "error",
+  LEX_INVALID_ESCAPE: "error",
+  PARSE_EXPECTED_DECLARATION: "error",
+  PARSE_EXPECTED_TOKEN: "error",
+  PARSE_UNEXPECTED_TOKEN: "error",
+  PARSE_MISSING_REQUIRED_DECLARATION: "error"
+};
+
+function clonePosition(position: SourcePosition): SourcePosition {
+  return {
+    offset: position.offset,
+    line: position.line,
+    column: position.column
+  };
+}
+
+export function createDiagnosticSpan(
+  start: SourcePosition,
+  end: SourcePosition,
+  file = DEFAULT_DIAGNOSTIC_FILE
+): DiagnosticSpan {
+  return {
+    file,
+    start: clonePosition(start),
+    end: clonePosition(end)
+  };
+}
+
+export function createDiagnosticSpanFromRange(
+  range: SourceRange,
+  file = DEFAULT_DIAGNOSTIC_FILE
+): DiagnosticSpan {
+  return createDiagnosticSpan(range.start, range.end, file);
+}
+
+export function createDiagnostic(
+  code: DiagnosticCode,
+  message: string,
+  span: DiagnosticSpan
+): Diagnostic {
+  return {
+    code,
+    message,
+    severity: DIAGNOSTIC_SEVERITY_BY_CODE[code],
+    span
+  };
+}
+
+export function emitDiagnostic(diagnostics: Diagnostic[], diagnostic: Diagnostic): void {
+  diagnostics.push(diagnostic);
 }

--- a/compiler/src/index.ts
+++ b/compiler/src/index.ts
@@ -17,7 +17,13 @@ export function parseGoalDeclaration(input: string): GoalAstNode {
 
 export { lex } from "./lexer.ts";
 export { parseLsDocument } from "./parser.ts";
+export {
+  createDiagnostic,
+  createDiagnosticSpan,
+  createDiagnosticSpanFromRange,
+  emitDiagnostic
+} from "./diagnostics.ts";
 export type { DocumentAstNode, GoalDeclarationAstNode, CapabilityDeclarationAstNode, CheckDeclarationAstNode, SourcePosition, SourceRange } from "./ast.ts";
-export type { Diagnostic, DiagnosticCode } from "./diagnostics.ts";
+export type { Diagnostic, DiagnosticCode, DiagnosticSeverity, DiagnosticSpan } from "./diagnostics.ts";
 export type { LexResult, Token, TokenKind } from "./lexer.ts";
 export type { ParseResult } from "./parser.ts";

--- a/compiler/src/lexer.ts
+++ b/compiler/src/lexer.ts
@@ -1,5 +1,11 @@
 import type { SourcePosition, SourceRange } from "./ast.ts";
-import type { Diagnostic } from "./diagnostics.ts";
+import {
+  createDiagnostic,
+  createDiagnosticSpan,
+  emitDiagnostic,
+  type Diagnostic,
+  type DiagnosticCode
+} from "./diagnostics.ts";
 
 export type TokenKind =
   | "GoalKeyword"
@@ -113,12 +119,11 @@ export function lex(input: string): LexResult {
     });
   }
 
-  function addDiagnostic(code: Diagnostic["code"], message: string, start: SourcePosition, end: SourcePosition): void {
-    diagnostics.push({
-      code,
-      message,
-      range: createRange(start, end)
-    });
+  function addDiagnostic(code: DiagnosticCode, message: string, start: SourcePosition, end: SourcePosition): void {
+    emitDiagnostic(
+      diagnostics,
+      createDiagnostic(code, message, createDiagnosticSpan(start, end))
+    );
   }
 
   while (index < source.length) {

--- a/compiler/src/parser.ts
+++ b/compiler/src/parser.ts
@@ -6,7 +6,13 @@ import type {
   SourcePosition,
   SourceRange
 } from "./ast.ts";
-import type { Diagnostic, DiagnosticCode } from "./diagnostics.ts";
+import {
+  createDiagnostic,
+  createDiagnosticSpanFromRange,
+  emitDiagnostic,
+  type Diagnostic,
+  type DiagnosticCode
+} from "./diagnostics.ts";
 import { lex, type Token } from "./lexer.ts";
 
 export interface ParseResult {
@@ -352,19 +358,25 @@ class Parser {
   }
 
   private addDiagnostic(code: DiagnosticCode, message: string, token: Token): void {
-    this.diagnostics.push({
-      code,
-      message,
-      range: createRange(token.range.start, token.range.end)
-    });
+    emitDiagnostic(
+      this.diagnostics,
+      createDiagnostic(
+        code,
+        message,
+        createDiagnosticSpanFromRange(createRange(token.range.start, token.range.end))
+      )
+    );
   }
 
   private addDiagnosticAtRange(code: DiagnosticCode, message: string, range: SourceRange): void {
-    this.diagnostics.push({
-      code,
-      message,
-      range: createRange(range.start, range.end)
-    });
+    emitDiagnostic(
+      this.diagnostics,
+      createDiagnostic(
+        code,
+        message,
+        createDiagnosticSpanFromRange(createRange(range.start, range.end))
+      )
+    );
   }
 }
 

--- a/compiler/test/lexer.test.ts
+++ b/compiler/test/lexer.test.ts
@@ -40,8 +40,10 @@ test("lex reports unterminated strings with source location", () => {
 
   assert.ok(result.diagnostics.length > 0);
   assert.equal(result.diagnostics[0].code, "LEX_UNTERMINATED_STRING");
-  assert.equal(result.diagnostics[0].range.start.line, 1);
-  assert.equal(result.diagnostics[0].range.start.column, 6);
+  assert.equal(result.diagnostics[0].severity, "error");
+  assert.equal(result.diagnostics[0].span.file, "<input>");
+  assert.equal(result.diagnostics[0].span.start.line, 1);
+  assert.equal(result.diagnostics[0].span.start.column, 6);
 });
 
 test("lex reports invalid escape range at the escape sequence", () => {
@@ -54,8 +56,10 @@ test("lex reports invalid escape range at the escape sequence", () => {
   );
 
   assert.notEqual(invalidEscape, undefined);
-  assert.equal(invalidEscape?.range.start.line, 1);
-  assert.equal(invalidEscape?.range.start.column, 11);
+  assert.equal(invalidEscape?.severity, "error");
+  assert.equal(invalidEscape?.span.file, "<input>");
+  assert.equal(invalidEscape?.span.start.line, 1);
+  assert.equal(invalidEscape?.span.start.column, 11);
 
   const stringToken = result.tokens.find((token) => token.kind === "StringLiteral");
   assert.notEqual(stringToken, undefined);

--- a/compiler/test/parser.test.ts
+++ b/compiler/test/parser.test.ts
@@ -50,7 +50,10 @@ test("parseLsDocument returns actionable diagnostics for missing goal", () => {
     )
   );
   assert.ok(
-    result.diagnostics.every((diagnostic) => diagnostic.range.start.line >= 1)
+    result.diagnostics.every((diagnostic) => diagnostic.span.start.line >= 1)
+  );
+  assert.ok(
+    result.diagnostics.every((diagnostic) => diagnostic.severity === "error")
   );
 });
 
@@ -77,7 +80,9 @@ test("parseLsDocument returns actionable diagnostics for unquoted goal string", 
     ).length,
     0
   );
-  assert.equal(result.diagnostics[0].range.start.line, 1);
+  assert.equal(result.diagnostics[0].severity, "error");
+  assert.equal(result.diagnostics[0].span.file, "<input>");
+  assert.equal(result.diagnostics[0].span.start.line, 1);
 });
 
 test("parseLsDocument does not discard declarations when goal is missing", () => {
@@ -122,7 +127,7 @@ test("parseLsDocument anchors missing capability diagnostic near goal declaratio
   );
 
   assert.notEqual(capabilityDiagnostic, undefined);
-  assert.equal(capabilityDiagnostic?.range.start.line, 1);
+  assert.equal(capabilityDiagnostic?.span.start.line, 1);
 });
 
 test("parseLsDocument anchors missing check diagnostic near last capability", () => {
@@ -135,7 +140,7 @@ test("parseLsDocument anchors missing check diagnostic near last capability", ()
   );
 
   assert.notEqual(checkDiagnostic, undefined);
-  assert.equal(checkDiagnostic?.range.start.line, 2);
+  assert.equal(checkDiagnostic?.span.start.line, 2);
 });
 
 test("parseLsDocument suppresses missing capability diagnostic when capability is malformed", () => {

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -5,3 +5,4 @@ Language and contract specification drafts.
 ## Language
 
 - `docs/spec/minimal-ls-grammar.md` - M0 minimal grammar (`goal`, `capability`, `check`)
+- `docs/spec/compiler-ast-diagnostics.md` - M0 exported AST and diagnostic primitives

--- a/docs/spec/compiler-ast-diagnostics.md
+++ b/docs/spec/compiler-ast-diagnostics.md
@@ -1,0 +1,43 @@
+# Compiler AST and Diagnostics Primitives (M0 / Issue #7)
+
+This document describes the minimal exported compiler primitives used by M0 lexer/parser work.
+
+## AST Types
+
+Exported from `compiler/src/index.ts`:
+
+- `SourcePosition`: `{ offset, line, column }`
+- `SourceRange`: `{ start, end }`
+- `GoalDeclarationAstNode`
+- `CapabilityDeclarationAstNode`
+- `CheckDeclarationAstNode`
+- `DocumentAstNode`
+
+All declaration nodes carry `range: SourceRange` for source spans.
+
+## Diagnostic Shape
+
+Exported from `compiler/src/index.ts`:
+
+- `DiagnosticCode`
+- `DiagnosticSeverity`
+- `DiagnosticSpan`
+- `Diagnostic`
+
+`Diagnostic` shape:
+
+- `code`: stable machine-readable code.
+- `message`: actionable human-readable text.
+- `severity`: currently `error` for M0 diagnostics.
+- `span`: `{ file, start, end }`.
+
+M0 parsers/lexers use `"<input>"` for `span.file` when parsing in-memory text.
+
+## Emission Helpers
+
+The following utilities are exported for consistent diagnostic creation:
+
+- `createDiagnosticSpan(start, end, file?)`
+- `createDiagnosticSpanFromRange(range, file?)`
+- `createDiagnostic(code, message, span)`
+- `emitDiagnostic(diagnostics, diagnostic)`


### PR DESCRIPTION
## Summary
- add explicit diagnostic primitives with `severity` and `span` (`file`, `start`, `end`)
- add reusable diagnostic emission helpers and wire lexer/parser to use them
- update lexer/parser tests to assert diagnostic format (`severity` + `span`) on invalid input
- document exported compiler AST + diagnostic primitives in spec docs

Closes #7.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`