### PR TITLE
feat(contracts): draft PolicyProfile v0 JSON Schema and validation rules

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -10,3 +10,4 @@ Language and contract specification drafts.
 ## Contracts
 
 - `docs/spec/semanticir-v0.md` - M0 SemanticIR v0 schema and fixture set
+- `docs/spec/policyprofile-v0.md` - M0 PolicyProfile v0 schema, invariants, and runtime validation contract

--- a/docs/spec/examples/policyprofile/invalid/escalation-rule-missing-min-approvals.json
+++ b/docs/spec/examples/policyprofile/invalid/escalation-rule-missing-min-approvals.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "profile_id": "policy-staging-rule-missing-min-approvals",
+    "environment": "staging",
+    "created_at": "2026-02-20T18:00:00Z",
+    "source": "runtime/defaults/staging"
+  },
+  "capability_policy": {
+    "allow": ["filesystem.read", "network.http"],
+    "deny": ["git.push"],
+    "escalation_requirements": {
+      "default": "manual_approval",
+      "rules": [
+        {
+          "capability": "git.push",
+          "escalation_level": "owner",
+          "reason_required": true
+        }
+      ]
+    }
+  },
+  "constraints": {
+    "max_autonomous_steps": 40,
+    "max_runtime_seconds": 450,
+    "require_human_review_on_policy_violation": true
+  }
+}

--- a/docs/spec/examples/policyprofile/invalid/manual-approval-without-rules.json
+++ b/docs/spec/examples/policyprofile/invalid/manual-approval-without-rules.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "profile_id": "policy-staging-missing-rules",
+    "environment": "staging",
+    "created_at": "2026-02-20T18:00:00Z",
+    "source": "runtime/defaults/staging"
+  },
+  "capability_policy": {
+    "allow": ["filesystem.read", "network.http"],
+    "deny": ["git.push"],
+    "escalation_requirements": {
+      "default": "manual_approval",
+      "rules": []
+    }
+  },
+  "constraints": {
+    "max_autonomous_steps": 40,
+    "max_runtime_seconds": 450,
+    "require_human_review_on_policy_violation": true
+  }
+}

--- a/docs/spec/examples/policyprofile/invalid/missing-schema-version.json
+++ b/docs/spec/examples/policyprofile/invalid/missing-schema-version.json
@@ -1,0 +1,21 @@
+{
+  "metadata": {
+    "profile_id": "policy-dev-default",
+    "environment": "development",
+    "created_at": "2026-02-20T18:00:00Z",
+    "source": "runtime/defaults/dev"
+  },
+  "capability_policy": {
+    "allow": ["filesystem.read", "network.http", "shell.exec"],
+    "deny": ["git.push"],
+    "escalation_requirements": {
+      "default": "none",
+      "rules": []
+    }
+  },
+  "constraints": {
+    "max_autonomous_steps": 100,
+    "max_runtime_seconds": 900,
+    "require_human_review_on_policy_violation": true
+  }
+}

--- a/docs/spec/examples/policyprofile/invalid/production-default-without-manual-approval.json
+++ b/docs/spec/examples/policyprofile/invalid/production-default-without-manual-approval.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "profile_id": "policy-prod-invalid-default",
+    "environment": "production",
+    "created_at": "2026-02-20T18:00:00Z",
+    "source": "runtime/defaults/prod"
+  },
+  "capability_policy": {
+    "allow": ["filesystem.read", "network.http"],
+    "deny": ["filesystem.write", "shell.exec", "git.push"],
+    "escalation_requirements": {
+      "default": "none",
+      "rules": []
+    }
+  },
+  "constraints": {
+    "max_autonomous_steps": 25,
+    "max_runtime_seconds": 300,
+    "require_human_review_on_policy_violation": true
+  }
+}

--- a/docs/spec/examples/policyprofile/valid/development-default.json
+++ b/docs/spec/examples/policyprofile/valid/development-default.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "profile_id": "policy-dev-default",
+    "environment": "development",
+    "created_at": "2026-02-20T18:00:00Z",
+    "source": "runtime/defaults/dev"
+  },
+  "capability_policy": {
+    "allow": ["filesystem.read", "network.http", "shell.exec"],
+    "deny": ["git.push"],
+    "escalation_requirements": {
+      "default": "none",
+      "rules": []
+    }
+  },
+  "constraints": {
+    "max_autonomous_steps": 100,
+    "max_runtime_seconds": 900,
+    "require_human_review_on_policy_violation": true
+  }
+}

--- a/docs/spec/examples/policyprofile/valid/production-restricted.json
+++ b/docs/spec/examples/policyprofile/valid/production-restricted.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "0.1.0",
+  "metadata": {
+    "profile_id": "policy-prod-restricted",
+    "environment": "production",
+    "created_at": "2026-02-20T18:00:00Z",
+    "source": "runtime/defaults/prod"
+  },
+  "capability_policy": {
+    "allow": ["filesystem.read", "network.http"],
+    "deny": ["filesystem.write", "shell.exec", "git.push"],
+    "escalation_requirements": {
+      "default": "manual_approval",
+      "rules": [
+        {
+          "capability": "filesystem.write",
+          "escalation_level": "team_lead",
+          "min_approvals": 1,
+          "reason_required": true
+        },
+        {
+          "capability": "git.push",
+          "escalation_level": "owner",
+          "min_approvals": 2,
+          "reason_required": true
+        }
+      ]
+    }
+  },
+  "constraints": {
+    "max_autonomous_steps": 25,
+    "max_runtime_seconds": 300,
+    "require_human_review_on_policy_violation": true
+  }
+}

--- a/docs/spec/policyprofile-v0.md
+++ b/docs/spec/policyprofile-v0.md
@@ -1,0 +1,33 @@
+# PolicyProfile v0
+
+PolicyProfile v0 is the first machine-readable policy contract for runtime gating in M0.
+
+## Contract Goals
+- Enforce explicit contract versioning via `schema_version`.
+- Define capability allow/deny controls through `capability_policy.allow` and `capability_policy.deny`.
+- Encode escalation requirements through `capability_policy.escalation_requirements`.
+
+## Validation Invariants
+- `schema_version` is mandatory and fixed to `0.1.0`.
+- At least one capability list must be non-empty (`allow` or `deny`).
+- `metadata.environment` is required and constrained to `development`, `staging`, or `production`.
+- `production` profiles must default to `manual_approval` escalation.
+- `manual_approval` default requires at least one explicit escalation rule.
+- Each escalation rule requires `capability`, `escalation_level`, `min_approvals`, and `reason_required`.
+
+## Runtime Validation Contract
+- Runtime contract loaders must validate PolicyProfile JSON against `policyprofile-v0.schema.json` before execution.
+- Validation failures are hard-stop errors and must block autonomous continuation.
+- Validation output should include actionable field-level data (`instancePath`, `keyword`, `message`) for diagnostics.
+- Version incompatibility must be reported explicitly at the loader boundary.
+
+## Files
+- Schema: `docs/spec/schemas/policyprofile-v0.schema.json`
+- Valid examples:
+  - `docs/spec/examples/policyprofile/valid/development-default.json`
+  - `docs/spec/examples/policyprofile/valid/production-restricted.json`
+- Invalid examples:
+  - `docs/spec/examples/policyprofile/invalid/missing-schema-version.json`
+  - `docs/spec/examples/policyprofile/invalid/production-default-without-manual-approval.json`
+  - `docs/spec/examples/policyprofile/invalid/manual-approval-without-rules.json`
+  - `docs/spec/examples/policyprofile/invalid/escalation-rule-missing-min-approvals.json`

--- a/docs/spec/schemas/policyprofile-v0.schema.json
+++ b/docs/spec/schemas/policyprofile-v0.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://l-semantica.dev/spec/schemas/policyprofile-v0.schema.json",
+  "title": "PolicyProfile v0",
+  "description": "Canonical v0 contract for runtime policy and escalation controls.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "metadata", "capability_policy", "constraints"],
+  "properties": {
+    "schema_version": {
+      "const": "0.1.0",
+      "description": "Contract version for PolicyProfile compatibility."
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile_id", "environment", "created_at", "source"],
+      "properties": {
+        "profile_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "environment": {
+          "type": "string",
+          "enum": ["development", "staging", "production"]
+        },
+        "created_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "capability_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allow", "deny", "escalation_requirements"],
+      "properties": {
+        "allow": {
+          "$ref": "#/$defs/capabilityList"
+        },
+        "deny": {
+          "$ref": "#/$defs/capabilityList"
+        },
+        "escalation_requirements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["default", "rules"],
+          "properties": {
+            "default": {
+              "type": "string",
+              "enum": ["none", "manual_approval"]
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/escalationRule"
+              }
+            }
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "properties": {
+            "allow": {
+              "type": "array",
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "properties": {
+            "deny": {
+              "type": "array",
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_autonomous_steps",
+        "max_runtime_seconds",
+        "require_human_review_on_policy_violation"
+      ],
+      "properties": {
+        "max_autonomous_steps": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_runtime_seconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "require_human_review_on_policy_violation": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "capabilityName": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9._-]*$"
+    },
+    "capabilityList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/capabilityName"
+      },
+      "uniqueItems": true
+    },
+    "escalationRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability", "escalation_level", "min_approvals", "reason_required"],
+      "properties": {
+        "capability": {
+          "$ref": "#/$defs/capabilityName"
+        },
+        "escalation_level": {
+          "type": "string",
+          "enum": ["team_lead", "security", "owner"]
+        },
+        "min_approvals": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "reason_required": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["metadata"],
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "required": ["environment"],
+            "properties": {
+              "environment": {
+                "const": "production"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "capability_policy": {
+            "type": "object",
+            "properties": {
+              "escalation_requirements": {
+                "type": "object",
+                "required": ["default"],
+                "properties": {
+                  "default": {
+                    "const": "manual_approval"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["capability_policy"],
+        "properties": {
+          "capability_policy": {
+            "type": "object",
+            "required": ["escalation_requirements"],
+            "properties": {
+              "escalation_requirements": {
+                "type": "object",
+                "required": ["default"],
+                "properties": {
+                  "default": {
+                    "const": "manual_approval"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "capability_policy": {
+            "type": "object",
+            "properties": {
+              "escalation_requirements": {
+                "type": "object",
+                "required": ["rules"],
+                "properties": {
+                  "rules": {
+                    "type": "array",
+                    "minItems": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,3 +1,7 @@
 # Runtime
 
 Execution engine, policy enforcement, and replay support.
+
+## Contract Specs
+- `docs/spec/semanticir-v0.md`
+- `docs/spec/policyprofile-v0.md`

--- a/runtime/test/policyprofile-schema.test.ts
+++ b/runtime/test/policyprofile-schema.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { Ajv2020 } from "ajv/dist/2020.js";
+
+function loadJson(relativePathFromThisTest: string): unknown {
+  const fileContents = readFileSync(new URL(relativePathFromThisTest, import.meta.url), "utf8");
+  return JSON.parse(fileContents) as unknown;
+}
+
+const policyProfileSchema = loadJson("../../docs/spec/schemas/policyprofile-v0.schema.json") as object;
+const validExamples = [
+  {
+    name: "development-default",
+    value: loadJson("../../docs/spec/examples/policyprofile/valid/development-default.json")
+  },
+  {
+    name: "production-restricted",
+    value: loadJson("../../docs/spec/examples/policyprofile/valid/production-restricted.json")
+  }
+];
+const invalidExamples = [
+  {
+    name: "missing-schema-version",
+    value: loadJson("../../docs/spec/examples/policyprofile/invalid/missing-schema-version.json"),
+    expectedErrorSnippet: "schema_version"
+  },
+  {
+    name: "production-default-without-manual-approval",
+    value: loadJson(
+      "../../docs/spec/examples/policyprofile/invalid/production-default-without-manual-approval.json"
+    ),
+    expectedErrorSnippet: "capability_policy/escalation_requirements/default"
+  },
+  {
+    name: "manual-approval-without-rules",
+    value: loadJson("../../docs/spec/examples/policyprofile/invalid/manual-approval-without-rules.json"),
+    expectedErrorSnippet: "rules"
+  },
+  {
+    name: "escalation-rule-missing-min-approvals",
+    value: loadJson(
+      "../../docs/spec/examples/policyprofile/invalid/escalation-rule-missing-min-approvals.json"
+    ),
+    expectedErrorSnippet: "min_approvals"
+  }
+];
+
+const ajv = new Ajv2020({ allErrors: true });
+const validatePolicyProfile = ajv.compile(policyProfileSchema);
+
+for (const validExample of validExamples) {
+  test(`PolicyProfile v0 schema accepts valid example: ${validExample.name}`, () => {
+    const valid = validatePolicyProfile(validExample.value);
+
+    assert.equal(valid, true, ajv.errorsText(validatePolicyProfile.errors, { separator: "\n" }));
+  });
+}
+
+for (const invalidExample of invalidExamples) {
+  test(`PolicyProfile v0 schema rejects invalid example: ${invalidExample.name}`, () => {
+    const valid = validatePolicyProfile(invalidExample.value);
+    const errorText = ajv.errorsText(validatePolicyProfile.errors, { separator: "\n" });
+
+    assert.equal(valid, false);
+    assert.equal(errorText.length > 0, true);
+    assert.equal(
+      errorText.includes(invalidExample.expectedErrorSnippet),
+      true,
+      `Expected "${invalidExample.expectedErrorSnippet}" in error output:\n${errorText}`
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add PolicyProfile v0 JSON Schema with mandatory `schema_version`, required metadata, capability allow/deny model, and escalation requirements
- encode minimal policy invariants (environment constraints, production escalation default, manual-approval rule requirements)
- add valid policy fixtures for two environments (`development`, `production`)
- add invalid fixtures and runtime `ajv` tests that assert actionable rejection behavior
- document PolicyProfile runtime-side validation contract and link it from spec/runtime docs

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #9