### PR TITLE
M1: VerificationContract v1 schema, fixtures, docs, and runtime validation (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Before `1.0.0`, any release (minor or patch) may include breaking changes.
 - FeedbackTensor v1 contract draft schema and spec documentation (`docs/spec/schemas/feedbacktensor-v1.schema.json`, `docs/spec/feedbacktensor-v1.md`).
 - FeedbackTensor valid/invalid fixture corpus for schema conformance coverage (`docs/spec/examples/feedbacktensor/`).
 - Runtime schema validation tests for FeedbackTensor fixtures with actionable error assertions (`runtime/test/feedbacktensor-schema.test.ts`).
+- VerificationContract v1 contract draft schema and spec documentation (`docs/spec/schemas/verificationcontract-v1.schema.json`, `docs/spec/verificationcontract-v1.md`).
+- VerificationContract valid/invalid fixture corpus and runtime schema validation tests (`docs/spec/examples/verificationcontract/`, `runtime/test/verificationcontract-schema.test.ts`).
+- Runtime contract loader support for VerificationContract v1 validation and compatibility checks (`runtime/src/contracts.ts`, `runtime/test/contract-loader.test.ts`).
 
 ## [0.1.0] - 2026-02-21
 ### Added

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -12,4 +12,5 @@ Language and contract specification drafts.
 - `docs/spec/semanticir-v0.md` - M0 SemanticIR v0 schema and fixture set
 - `docs/spec/policyprofile-v0.md` - M0 PolicyProfile v0 schema, invariants, and runtime validation contract
 - `docs/spec/feedbacktensor-v1.md` - M1 FeedbackTensor v1 schema, compatibility notes, and fixture set
+- `docs/spec/verificationcontract-v1.md` - M1 VerificationContract v1 schema, continuation-gate semantics, and fixture set
 - `docs/spec/trace-ledger-v0.md` - M0 runtime trace ledger v0 schema and emission contract

--- a/docs/spec/examples/verificationcontract/invalid/invalid-on-failure-decision.json
+++ b/docs/spec/examples/verificationcontract/invalid/invalid-on-failure-decision.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "1.0.0",
+  "contract_id": "verification-invalid-on-failure",
+  "generated_at": "2026-02-21T16:33:00Z",
+  "requirements": {
+    "tests": [
+      {
+        "id": "runtime.contract-loader",
+        "description": "Runtime contract loader tests pass",
+        "required": true
+      }
+    ],
+    "static_analysis": [
+      {
+        "id": "workspace.typecheck",
+        "description": "Workspace typecheck succeeds",
+        "required": true
+      }
+    ],
+    "policy_assertions": [
+      {
+        "id": "policy.review-on-violation",
+        "policy_path": "constraints.require_human_review_on_policy_violation",
+        "expected": true,
+        "required": true
+      }
+    ]
+  },
+  "pass_criteria": {
+    "minimum_required_checks_pass_ratio": 1,
+    "require_all_policy_assertions": true,
+    "max_warning_count": 0
+  },
+  "continuation": {
+    "on_success": "continue",
+    "on_failure": "continue",
+    "require_policy_profile": true,
+    "required_feedback_tensor_fields": [
+      "failure_signal",
+      "confidence",
+      "provenance"
+    ]
+  }
+}

--- a/docs/spec/examples/verificationcontract/invalid/missing-schema-version.json
+++ b/docs/spec/examples/verificationcontract/invalid/missing-schema-version.json
@@ -1,0 +1,43 @@
+{
+  "contract_id": "verification-missing-schema-version",
+  "generated_at": "2026-02-21T16:32:00Z",
+  "requirements": {
+    "tests": [
+      {
+        "id": "runtime.contract-loader",
+        "description": "Runtime contract loader tests pass",
+        "required": true
+      }
+    ],
+    "static_analysis": [
+      {
+        "id": "workspace.typecheck",
+        "description": "Workspace typecheck succeeds",
+        "required": true
+      }
+    ],
+    "policy_assertions": [
+      {
+        "id": "policy.review-on-violation",
+        "policy_path": "constraints.require_human_review_on_policy_violation",
+        "expected": true,
+        "required": true
+      }
+    ]
+  },
+  "pass_criteria": {
+    "minimum_required_checks_pass_ratio": 1,
+    "require_all_policy_assertions": true,
+    "max_warning_count": 0
+  },
+  "continuation": {
+    "on_success": "continue",
+    "on_failure": "stop",
+    "require_policy_profile": true,
+    "required_feedback_tensor_fields": [
+      "failure_signal",
+      "confidence",
+      "provenance"
+    ]
+  }
+}

--- a/docs/spec/examples/verificationcontract/invalid/pass-ratio-out-of-range.json
+++ b/docs/spec/examples/verificationcontract/invalid/pass-ratio-out-of-range.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "1.0.0",
+  "contract_id": "verification-pass-ratio-out-of-range",
+  "generated_at": "2026-02-21T16:34:00Z",
+  "requirements": {
+    "tests": [
+      {
+        "id": "runtime.contract-loader",
+        "description": "Runtime contract loader tests pass",
+        "required": true
+      }
+    ],
+    "static_analysis": [
+      {
+        "id": "workspace.typecheck",
+        "description": "Workspace typecheck succeeds",
+        "required": true
+      }
+    ],
+    "policy_assertions": [
+      {
+        "id": "policy.review-on-violation",
+        "policy_path": "constraints.require_human_review_on_policy_violation",
+        "expected": true,
+        "required": true
+      }
+    ]
+  },
+  "pass_criteria": {
+    "minimum_required_checks_pass_ratio": 1.2,
+    "require_all_policy_assertions": true,
+    "max_warning_count": 0
+  },
+  "continuation": {
+    "on_success": "continue",
+    "on_failure": "stop",
+    "require_policy_profile": true,
+    "required_feedback_tensor_fields": [
+      "failure_signal",
+      "confidence",
+      "provenance"
+    ]
+  }
+}

--- a/docs/spec/examples/verificationcontract/invalid/tests-without-required-check.json
+++ b/docs/spec/examples/verificationcontract/invalid/tests-without-required-check.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "1.0.0",
+  "contract_id": "verification-tests-without-required-check",
+  "generated_at": "2026-02-21T16:35:00Z",
+  "requirements": {
+    "tests": [
+      {
+        "id": "runtime.trace-ledger",
+        "description": "Trace ledger emission tests pass",
+        "required": false
+      }
+    ],
+    "static_analysis": [
+      {
+        "id": "workspace.typecheck",
+        "description": "Workspace typecheck succeeds",
+        "required": true
+      }
+    ],
+    "policy_assertions": [
+      {
+        "id": "policy.review-on-violation",
+        "policy_path": "constraints.require_human_review_on_policy_violation",
+        "expected": true,
+        "required": true
+      }
+    ]
+  },
+  "pass_criteria": {
+    "minimum_required_checks_pass_ratio": 0.5,
+    "require_all_policy_assertions": true,
+    "max_warning_count": 1
+  },
+  "continuation": {
+    "on_success": "continue",
+    "on_failure": "escalate",
+    "require_policy_profile": true,
+    "required_feedback_tensor_fields": [
+      "failure_signal",
+      "confidence",
+      "provenance"
+    ]
+  }
+}

--- a/docs/spec/examples/verificationcontract/valid/escalate-on-failure-with-thresholds.json
+++ b/docs/spec/examples/verificationcontract/valid/escalate-on-failure-with-thresholds.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "1.0.0",
+  "contract_id": "verification-core-escalate-on-failure",
+  "generated_at": "2026-02-21T16:31:00Z",
+  "requirements": {
+    "tests": [
+      {
+        "id": "runtime.reliability-corpus",
+        "description": "Reliability corpus coverage tests pass",
+        "required": true
+      },
+      {
+        "id": "runtime.trace-ledger",
+        "description": "Trace ledger emission tests pass",
+        "required": false
+      }
+    ],
+    "static_analysis": [
+      {
+        "id": "workspace.typecheck",
+        "description": "Workspace typecheck succeeds",
+        "required": true
+      }
+    ],
+    "policy_assertions": [
+      {
+        "id": "policy.review-on-violation",
+        "policy_path": "constraints.require_human_review_on_policy_violation",
+        "expected": true,
+        "required": true
+      },
+      {
+        "id": "policy.max-autonomous-steps",
+        "policy_path": "constraints.max_autonomous_steps",
+        "expected": 8,
+        "required": false
+      }
+    ]
+  },
+  "pass_criteria": {
+    "minimum_required_checks_pass_ratio": 0.75,
+    "require_all_policy_assertions": true,
+    "max_warning_count": 1
+  },
+  "continuation": {
+    "on_success": "continue",
+    "on_failure": "escalate",
+    "require_policy_profile": true,
+    "required_feedback_tensor_fields": [
+      "failure_signal",
+      "confidence",
+      "alternatives",
+      "proposed_repair_action",
+      "provenance"
+    ]
+  }
+}

--- a/docs/spec/examples/verificationcontract/valid/strict-stop-on-failure.json
+++ b/docs/spec/examples/verificationcontract/valid/strict-stop-on-failure.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "1.0.0",
+  "contract_id": "verification-core-stop-on-failure",
+  "generated_at": "2026-02-21T16:30:00Z",
+  "requirements": {
+    "tests": [
+      {
+        "id": "runtime.contract-loader",
+        "description": "Runtime contract loader tests pass",
+        "required": true
+      },
+      {
+        "id": "runtime.feedbacktensor-schema",
+        "description": "FeedbackTensor schema fixture tests pass",
+        "required": true
+      }
+    ],
+    "static_analysis": [
+      {
+        "id": "workspace.lint",
+        "description": "Workspace lint succeeds",
+        "required": true
+      },
+      {
+        "id": "workspace.typecheck",
+        "description": "Workspace typecheck succeeds",
+        "required": true
+      }
+    ],
+    "policy_assertions": [
+      {
+        "id": "policy.production.manual-approval-default",
+        "policy_path": "capability_policy.escalation_requirements.default",
+        "expected": "manual_approval",
+        "required": true,
+        "rationale": "Production continuation must require manual approval by default"
+      }
+    ]
+  },
+  "pass_criteria": {
+    "minimum_required_checks_pass_ratio": 1,
+    "require_all_policy_assertions": true,
+    "max_warning_count": 0
+  },
+  "continuation": {
+    "on_success": "continue",
+    "on_failure": "stop",
+    "require_policy_profile": true,
+    "required_feedback_tensor_fields": [
+      "failure_signal",
+      "confidence",
+      "provenance"
+    ]
+  }
+}

--- a/docs/spec/schemas/verificationcontract-v1.schema.json
+++ b/docs/spec/schemas/verificationcontract-v1.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://l-semantica.dev/spec/schemas/verificationcontract-v1.schema.json",
+  "title": "VerificationContract v1",
+  "description": "Canonical v1 contract for verification-gated autonomous continuation requirements.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contract_id",
+    "generated_at",
+    "requirements",
+    "pass_criteria",
+    "continuation"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0",
+      "description": "Contract version for VerificationContract compatibility."
+    },
+    "contract_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$"
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tests", "static_analysis", "policy_assertions"],
+      "properties": {
+        "tests": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/checkRequirement"
+          },
+          "contains": {
+            "type": "object",
+            "required": ["required"],
+            "properties": {
+              "required": {
+                "const": true
+              }
+            }
+          },
+          "minContains": 1
+        },
+        "static_analysis": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/checkRequirement"
+          },
+          "contains": {
+            "type": "object",
+            "required": ["required"],
+            "properties": {
+              "required": {
+                "const": true
+              }
+            }
+          },
+          "minContains": 1
+        },
+        "policy_assertions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/policyAssertion"
+          },
+          "contains": {
+            "type": "object",
+            "required": ["required"],
+            "properties": {
+              "required": {
+                "const": true
+              }
+            }
+          },
+          "minContains": 1
+        }
+      }
+    },
+    "pass_criteria": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "minimum_required_checks_pass_ratio",
+        "require_all_policy_assertions",
+        "max_warning_count"
+      ],
+      "properties": {
+        "minimum_required_checks_pass_ratio": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "require_all_policy_assertions": {
+          "type": "boolean"
+        },
+        "max_warning_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "continuation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "on_success",
+        "on_failure",
+        "require_policy_profile",
+        "required_feedback_tensor_fields"
+      ],
+      "properties": {
+        "on_success": {
+          "type": "string",
+          "enum": ["continue"]
+        },
+        "on_failure": {
+          "type": "string",
+          "enum": ["escalate", "stop"]
+        },
+        "require_policy_profile": {
+          "type": "boolean"
+        },
+        "required_feedback_tensor_fields": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "failure_signal",
+              "confidence",
+              "alternatives",
+              "proposed_repair_action",
+              "provenance"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "checkRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description", "required"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "policyAssertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "policy_path", "expected", "required"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/spec/verificationcontract-v1.md
+++ b/docs/spec/verificationcontract-v1.md
@@ -1,0 +1,57 @@
+# VerificationContract v1
+
+VerificationContract v1 is the first machine-readable contract draft for verification-gated autonomous continuation in M1.
+
+## Contract Goals
+- Enforce explicit versioning through `schema_version`.
+- Define required verification checks across tests and static analysis.
+- Encode required policy assertions that must hold before continuation.
+- Define deterministic pass criteria and continuation behavior on success/failure.
+
+## Contract Shape (v1)
+- `schema_version` (required): fixed to `1.0.0`.
+- `contract_id` (required): non-empty identifier for the verification policy set.
+- `generated_at` (required): timestamp string that matches the schema's RFC3339/ISO-8601-style pattern with bounded date/time/offset components.
+- `requirements` (required object):
+  - `tests` (required array): required test checks; at least one entry and at least one entry with `required: true`.
+  - `static_analysis` (required array): required static checks; at least one entry and at least one entry with `required: true`.
+  - `policy_assertions` (required array): policy gates to verify; at least one entry and at least one entry with `required: true`.
+- `pass_criteria` (required object):
+  - `minimum_required_checks_pass_ratio` (required): number in `[0, 1]`.
+  - `require_all_policy_assertions` (required): boolean.
+  - `max_warning_count` (required): integer `>= 0`.
+- `continuation` (required object):
+  - `on_success` (required enum): `continue`.
+  - `on_failure` (required enum): `escalate` or `stop`.
+  - `require_policy_profile` (required): boolean policy-gate requirement.
+  - `required_feedback_tensor_fields` (required array): required FeedbackTensor sections for verification evidence.
+
+## Composition Notes
+- `PolicyProfile` composition:
+  - Verification policy assertions target PolicyProfile paths (for example escalation defaults and capability controls).
+  - If `require_policy_profile` is true, runtime continuation gating must require a valid PolicyProfile contract before autonomous continuation.
+- `FeedbackTensor` composition:
+  - VerificationContract requires explicit FeedbackTensor fields as evidence inputs for continuation decisions.
+  - Missing required FeedbackTensor evidence fields should be treated as incomplete verification and block autonomous continuation.
+
+## Compatibility and Versioning Notes
+- VerificationContract v1 uses semantic version `1.0.0` for the first stable major-family draft.
+- Consumers using this schema draft must reject any payload where `schema_version` is not exactly `1.0.0`.
+- Additive changes should be introduced via a new published schema/doc revision (for example, a future `1.x` file) with explicit compatibility notes.
+- Any field removal, required-field addition, enum narrowing, or semantic reinterpretation requires a major version bump and migration notes.
+
+## Runtime Validation Contract
+- Runtime-side schema tests must validate all committed valid fixtures and reject all committed invalid fixtures.
+- Runtime loaders must reject invalid and incompatible VerificationContract payloads with actionable field-level details (`instancePath`, `keyword`, `message`).
+- Verification failure states are hard-stop conditions for autonomous continuation paths.
+
+## Files
+- Schema: `docs/spec/schemas/verificationcontract-v1.schema.json`
+- Valid examples:
+  - `docs/spec/examples/verificationcontract/valid/strict-stop-on-failure.json`
+  - `docs/spec/examples/verificationcontract/valid/escalate-on-failure-with-thresholds.json`
+- Invalid examples:
+  - `docs/spec/examples/verificationcontract/invalid/missing-schema-version.json`
+  - `docs/spec/examples/verificationcontract/invalid/invalid-on-failure-decision.json`
+  - `docs/spec/examples/verificationcontract/invalid/pass-ratio-out-of-range.json`
+  - `docs/spec/examples/verificationcontract/invalid/tests-without-required-check.json`

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -6,13 +6,14 @@ Execution engine, policy enforcement, and replay support.
 - `docs/spec/semanticir-v0.md`
 - `docs/spec/policyprofile-v0.md`
 - `docs/spec/feedbacktensor-v1.md`
+- `docs/spec/verificationcontract-v1.md`
 - `docs/spec/trace-ledger-v0.md`
 
 ## Contract Loader
-- `loadRuntimeContracts(input)` validates `semanticIr` and `policyProfile` payloads against v0 schemas.
+- `loadRuntimeContracts(input)` validates `semanticIr`, `policyProfile`, and `verificationContract` payloads against published schema versions.
 - Validation failures use `ContractValidationError` with:
   - `code`: `INVALID_INPUT`, `SCHEMA_VALIDATION_FAILED`, or `VERSION_INCOMPATIBLE`
-  - `contract`: `RuntimeContracts`, `SemanticIR`, or `PolicyProfile`
+  - `contract`: `RuntimeContracts`, `SemanticIR`, `PolicyProfile`, or `VerificationContract`
   - `issues`: field-level validation details (`instancePath`, `keyword`, `message`)
 - Setup failures (for example unreadable schema files or resolver initialization failures) may throw standard `Error`.
 

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -189,13 +189,16 @@ export {
   ContractValidationError,
   SUPPORTED_POLICY_PROFILE_SCHEMA_VERSION,
   SUPPORTED_SEMANTIC_IR_SCHEMA_VERSION,
+  SUPPORTED_VERIFICATION_CONTRACT_SCHEMA_VERSION,
   loadPolicyProfileContract,
   loadRuntimeContracts,
   loadSemanticIrContract,
+  loadVerificationContract,
   type ContractName,
   type ContractValidationCode,
   type ContractValidationIssue,
   type PolicyProfileContract,
   type RuntimeContracts,
-  type SemanticIrContract
+  type SemanticIrContract,
+  type VerificationContract
 } from "./contracts.ts";

--- a/runtime/test/verificationcontract-schema.test.ts
+++ b/runtime/test/verificationcontract-schema.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { Ajv2020 } from "ajv/dist/2020.js";
+
+function loadJson(relativePathFromThisTest: string): unknown {
+  const fileContents = readFileSync(new URL(relativePathFromThisTest, import.meta.url), "utf8");
+  return JSON.parse(fileContents) as unknown;
+}
+
+const verificationContractSchema = loadJson(
+  "../../docs/spec/schemas/verificationcontract-v1.schema.json"
+) as object;
+const validExamples = [
+  {
+    name: "strict-stop-on-failure",
+    value: loadJson("../../docs/spec/examples/verificationcontract/valid/strict-stop-on-failure.json")
+  },
+  {
+    name: "escalate-on-failure-with-thresholds",
+    value: loadJson(
+      "../../docs/spec/examples/verificationcontract/valid/escalate-on-failure-with-thresholds.json"
+    )
+  }
+];
+const invalidExamples = [
+  {
+    name: "missing-schema-version",
+    value: loadJson("../../docs/spec/examples/verificationcontract/invalid/missing-schema-version.json"),
+    expectedErrorSnippet: "schema_version"
+  },
+  {
+    name: "invalid-on-failure-decision",
+    value: loadJson(
+      "../../docs/spec/examples/verificationcontract/invalid/invalid-on-failure-decision.json"
+    ),
+    expectedErrorSnippet: "continuation/on_failure"
+  },
+  {
+    name: "pass-ratio-out-of-range",
+    value: loadJson("../../docs/spec/examples/verificationcontract/invalid/pass-ratio-out-of-range.json"),
+    expectedErrorSnippet: "minimum_required_checks_pass_ratio"
+  },
+  {
+    name: "tests-without-required-check",
+    value: loadJson(
+      "../../docs/spec/examples/verificationcontract/invalid/tests-without-required-check.json"
+    ),
+    expectedErrorSnippet: "requirements/tests"
+  }
+];
+
+function createVerificationContractValidator(): {
+  ajv: Ajv2020;
+  validateVerificationContract: ReturnType<Ajv2020["compile"]>;
+} {
+  const ajv = new Ajv2020({ allErrors: true });
+  const validateVerificationContract = ajv.compile(verificationContractSchema);
+  return { ajv, validateVerificationContract };
+}
+
+for (const validExample of validExamples) {
+  test(`VerificationContract v1 schema accepts valid example: ${validExample.name}`, () => {
+    const { ajv, validateVerificationContract } = createVerificationContractValidator();
+    const valid = validateVerificationContract(validExample.value);
+
+    assert.equal(valid, true, ajv.errorsText(validateVerificationContract.errors, { separator: "\n" }));
+  });
+}
+
+for (const invalidExample of invalidExamples) {
+  test(`VerificationContract v1 schema rejects invalid example: ${invalidExample.name}`, () => {
+    const { ajv, validateVerificationContract } = createVerificationContractValidator();
+    const valid = validateVerificationContract(invalidExample.value);
+    const errorText = ajv.errorsText(validateVerificationContract.errors, { separator: "\n" });
+
+    assert.equal(valid, false);
+    assert.equal(errorText.length > 0, true);
+    assert.equal(
+      errorText.includes(invalidExample.expectedErrorSnippet),
+      true,
+      `Expected "${invalidExample.expectedErrorSnippet}" in error output:\n${errorText}`
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add VerificationContract v1 schema draft at `docs/spec/schemas/verificationcontract-v1.schema.json`
- add VerificationContract contract doc with shape, composition notes, and compatibility semantics at `docs/spec/verificationcontract-v1.md`
- add valid/invalid VerificationContract fixtures under `docs/spec/examples/verificationcontract/`
- add runtime schema validation tests for VerificationContract fixtures in `runtime/test/verificationcontract-schema.test.ts`
- extend runtime contract loader support and version-compatibility checks for VerificationContract in `runtime/src/contracts.ts` and `runtime/test/contract-loader.test.ts`
- register the spec in `docs/spec/README.md`, `runtime/README.md`, and update `CHANGELOG.md`

## Scope
- Closes #32
- Out of scope: #29, #30, #33, #34, #35 implementation

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @l-semantica/runtime test`